### PR TITLE
Add support for npm workspaces

### DIFF
--- a/src/PackageDetails.ts
+++ b/src/PackageDetails.ts
@@ -4,6 +4,7 @@ export interface PackageDetails {
   humanReadablePathSpecifier: string
   pathSpecifier: string
   path: string
+  workspacePath?: string
   name: string
   isNested: boolean
   packageNames: string[]


### PR DESCRIPTION
This adds support for npm workspaces. You don't need to run it in the context of a workspace, you just target it from the top level as a nested dep and it works (as it should). This is a little different than how it handles yarn, but whatever. If we want to do this for real I can add tests and whatnot, try upstream etc but it seems like its low priority for the original maintainers. 